### PR TITLE
Bind this to componentDidMount method on handleAction for rollback operation

### DIFF
--- a/client/View/Operation.js
+++ b/client/View/Operation.js
@@ -27,7 +27,7 @@ module.exports = React.createClass({
             this.props.siloBasePath+"/inventory/operation/"+this.props.id+"/"+action,
             {method: "POST", body:"null"}
         )
-            .then(this.componentDidMount)
+            .then(this.componentDidMount.bind(this))
             .catch(msg=>AlertStore.error(msg.message))
     },
 

--- a/client/View/Operations.js
+++ b/client/View/Operations.js
@@ -3,7 +3,7 @@ const React = require('react');
 const {Row, Col, Button, Glyphicon} = require('react-bootstrap');
 const Modal = require('../Modal/OperationUploadModal');
 const BatchModal = require('../Modal/BatchUploadModal');
-const promisify = require('silo-core/client/Common/connectWithPromise');
+const promisify = require('../Common/connectWithPromise');
 const OperationEditor = promisify(require('../Editor/OperationEditor'));
 const Api = require('../Api');
 


### PR DESCRIPTION
Hi @dav-m85 ,

When rolling back operations, `this` was not binded to the `componentDidMount`, so there was an error saying "could not read props of undefined", this removes the problem.