### PR TITLE
Add check for router to avoid filter not being properly handled

### DIFF
--- a/client/View/Location.js
+++ b/client/View/Location.js
@@ -35,7 +35,9 @@ module.exports = React.createClass({
 
     handleChangeFilter: function(filters){
         const fil = filters.filter(a => a.type !== 'location')
-        this.props.router.setParams(fil);
+        if (this.props.router) {
+            this.props.router.setParams(fil);
+        }
         this.setState({filters: filters});
     },
 


### PR DESCRIPTION
In the location screen, we have this error on clicking "apply" in the operationeditor:

"Uncaught TypeError: Cannot read property 'setParams' of undefined"