### PR TITLE
Use left join on search with force batches to take batch-less operations into account

### DIFF
--- a/server/Inventory/OperationController.php
+++ b/server/Inventory/OperationController.php
@@ -310,8 +310,8 @@ class OperationController implements ControllerProviderInterface
 
             if ($forceBatches && !$withBatches) {
                 $query->addSelect('batches,product')
-                    ->innerJoin('operation.batches', 'batches')
-                    ->innerJoin('batches.product', 'product');
+                    ->leftJoin('operation.batches', 'batches')
+                    ->leftJoin('batches.product', 'product');
                 $withBatches = true;
             }
 


### PR DESCRIPTION
Hey @dav-m85 ,

For operations with no batches associated (e.g. parent assign), this makes the request return without these operations when using forceBatches, such as when generating the csv. Left join should encompass all of them