### PR TITLE
Fixes operation finder

### DIFF
--- a/server/Inventory/Collection/OperationCollection.php
+++ b/server/Inventory/Collection/OperationCollection.php
@@ -95,16 +95,6 @@ class OperationCollection extends ArrayCollection implements MarshallableInterfa
         });
     }
 
-    /**
-     * @return static
-     */
-    public function filterUndone()
-    {
-        return $this->filter(function (Operation $operation) {
-            return !$operation->getStatus()->isDone();
-        });
-    }
-
     public function marshall()
     {
         return array_map(

--- a/server/Inventory/Collection/OperationCollection.php
+++ b/server/Inventory/Collection/OperationCollection.php
@@ -95,6 +95,16 @@ class OperationCollection extends ArrayCollection implements MarshallableInterfa
         });
     }
 
+    /**
+     * @return static
+     */
+    public function filterUndone()
+    {
+        return $this->filter(function (Operation $operation) {
+            return !$operation->getStatus()->isDone();
+        });
+    }
+
     public function marshall()
     {
         return array_map(

--- a/server/Inventory/Finder/OperationFinder.php
+++ b/server/Inventory/Finder/OperationFinder.php
@@ -141,8 +141,11 @@ class OperationFinder extends \Silo\Inventory\Finder\AbstractFinder
      */
     public function isType($type)
     {
+        if(!is_array($type)) {
+            $type = [$type];
+        }
         $this->getQuery()
-            ->andWhere('type.name = :type')
+            ->andWhere('type in (:type)')
             ->setParameter('type', $type)
         ;
 
@@ -163,6 +166,7 @@ class OperationFinder extends \Silo\Inventory\Finder\AbstractFinder
             ->select('SUM(batch.quantity)')
             ->from('Inventory:Operation', 'o')
             ->innerJoin('o.batches', 'batch')
+            ->join('o.operationType', 'type')
             ->andWhere('batch.product = :product')
             ->setParameter('product', $product)
         ;
@@ -174,7 +178,9 @@ class OperationFinder extends \Silo\Inventory\Finder\AbstractFinder
     {
         $this->getQuery()
             ->select('COUNT(o)')
-            ->from('Inventory:Operation', 'o');
+            ->from('Inventory:Operation', 'o')
+            ->join('o.operationType', 'type')
+            ;
 
         if ($this->loadBatches) {
             $this->getQuery()

--- a/server/Inventory/Finder/OperationSetFinder.php
+++ b/server/Inventory/Finder/OperationSetFinder.php
@@ -19,8 +19,11 @@ class OperationSetFinder extends \Silo\Inventory\Finder\AbstractFinder
 
     public function isType($type)
     {
+        if(!is_array($type)) {
+            $type = [$type];
+        }
         $this->getQuery()
-            ->andWhere('type.name = :type')
+            ->andWhere('type.name in (:type)')
             ->setParameter('type', $type)
         ;
 


### PR DESCRIPTION
Salut @dav-m85 

Using filter type and the count operations in OperationFinder would lead to a doctrine fail because type is undefined.

Also allow type to be an array now