### PR TITLE
Restore filter by name on operation finder

### DIFF
--- a/server/Inventory/Finder/OperationFinder.php
+++ b/server/Inventory/Finder/OperationFinder.php
@@ -145,7 +145,7 @@ class OperationFinder extends \Silo\Inventory\Finder\AbstractFinder
             $type = [$type];
         }
         $this->getQuery()
-            ->andWhere('type in (:type)')
+            ->andWhere('type.name in (:type)')
             ->setParameter('type', $type)
         ;
 


### PR DESCRIPTION
Hi @dav-m85 

On altering the OperationFinder in #17 , I forgot this `.name` in this clause, breaking a lot of stuff :(